### PR TITLE
Setup JDK in YAML

### DIFF
--- a/.github/workflows/jdk.yml
+++ b/.github/workflows/jdk.yml
@@ -10,6 +10,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout repository
@@ -18,9 +20,21 @@ jobs:
       - name: Setup Java JDK
         uses: actions/setup-java@v4.7.1
         with:
-          java-version: 17
+          java-version: latest
           distribution: 'temurin'
           cache: gradle
+
+      - name: Check for latest JDK version
+        uses: actions/setup-java@v4.7.1
+        with:
+          java-version: latest
+          distribution: 'temurin'
+
+      - name: Verify JDK installation (java -version)
+        run: java -version
+
+      - name: Verify JDK installation (javac -version)
+        run: javac -version
 
       - name: Make gradlew executable
         run: chmod +x ./gradlew
@@ -30,3 +44,6 @@ jobs:
 
       - name: Run tests
         run: ./gradlew test
+
+      - name: Verify JDK installation (Gradle task)
+        run: ./gradlew printJavaVersion

--- a/Build.gradle.kts
+++ b/Build.gradle.kts
@@ -39,3 +39,9 @@ tasks.jar {
         exclude("META-INF/*.RSA")
     }
 }
+
+tasks.register("printJavaVersion") {
+    doLast {
+        println("Java version: ${System.getProperty("java.version")}")
+    }
+}


### PR DESCRIPTION
Update `.github/workflows/jdk.yml` to set up and verify the latest JDK version.

* Add `permissions` attribute in the `jobs` section to specify required permissions.
* Change `java-version` to `latest` in the `Setup Java JDK` step.
* Add a step to check for the latest JDK version.
* Add steps to run `java -version` and `javac -version` commands to verify the JDK installation.
* Add a step to run the Gradle task to verify the JDK installation.

Add a Gradle task in `build.gradle.kts` to print the Java version.

* Register a new Gradle task `printJavaVersion` to print the Java version.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Tokenblkguy83/Learning/pull/47?shareId=cfb8987d-01f4-4c32-be31-cb0aaa8c8d07).

## Summary by Sourcery

Update CI workflow to use and verify the latest JDK version.

Build:
- Add a `printJavaVersion` Gradle task to output the current Java version.

CI:
- Configure the workflow job to use the `latest` JDK version.
- Add steps to verify the installed JDK version using `java -version`, `javac -version`, and a Gradle task.
- Set `contents: read` permissions for the workflow job.